### PR TITLE
add .hdbs extension

### DIFF
--- a/grammars/handlebars.json
+++ b/grammars/handlebars.json
@@ -733,6 +733,7 @@
         "handlebars.html",
         "hbr",
         "hbrs",
+        "hdbs",
         "hbs",
         "mustache",
         "template",


### PR DESCRIPTION
Fairly straightforward, evidently apps for Zendesk use the `.hdbs` extension. 
